### PR TITLE
Add WooCommerce env prefix

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,5 +19,5 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  envPrefix: ["VITE_", "NEXT_PUBLIC_"],
+  envPrefix: ["VITE_", "NEXT_PUBLIC_", "WOOCOMMERCE_"],
 }));


### PR DESCRIPTION
## Summary
- allow Vite to read `WOOCOMMERCE_*` environment variables by adding the prefix in `vite.config.ts`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b260d3038832faf4925236be36777