### PR TITLE
Add pagination to logistics orders

### DIFF
--- a/src/components/logistics/ShipmentPagination.tsx
+++ b/src/components/logistics/ShipmentPagination.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+
+interface ShipmentPaginationProps {
+  totalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+}
+
+const ShipmentPagination: React.FC<ShipmentPaginationProps> = ({
+  totalPages,
+  currentPage,
+  onPageChange,
+}) => {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+              className={currentPage === 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+            />
+          </PaginationItem>
+
+          {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+            let pageNum;
+            if (totalPages <= 5) {
+              pageNum = i + 1;
+            } else {
+              if (currentPage <= 3) {
+                pageNum = i + 1;
+              } else if (currentPage >= totalPages - 2) {
+                pageNum = totalPages - 4 + i;
+              } else {
+                pageNum = currentPage - 2 + i;
+              }
+            }
+
+            return (
+              <PaginationItem key={pageNum}>
+                <PaginationLink
+                  onClick={() => onPageChange(pageNum)}
+                  isActive={currentPage === pageNum}
+                  className="cursor-pointer"
+                >
+                  {pageNum}
+                </PaginationLink>
+              </PaginationItem>
+            );
+          })}
+
+          <PaginationItem>
+            <PaginationNext
+              onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+              className={currentPage === totalPages ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+
+      <div className="text-center text-sm text-muted-foreground">
+        Page {currentPage} of {totalPages}
+      </div>
+    </div>
+  );
+};
+
+export default ShipmentPagination;

--- a/src/components/logistics/ShipmentTabs.tsx
+++ b/src/components/logistics/ShipmentTabs.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { Package, Truck, AlertTriangle, CheckCircle } from 'lucide-react';
 import ShipmentTable from './ShipmentTable';
+import ShipmentPagination from './ShipmentPagination';
 
 interface ShipmentTabsProps {
   readyToShipOrders: any[];
@@ -20,6 +21,11 @@ interface ShipmentTabsProps {
   onAddTracking: (orderId: number) => void;
   onViewTracking?: (orderId: number, trackingNumber: string) => void;
   getShipmentStatus: (order: any) => { status: string; color: string };
+  processingTotalPages: number;
+  shippedTotalPages: number;
+  onHoldTotalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
 }
 
 const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
@@ -36,6 +42,11 @@ const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
   onAddTracking,
   onViewTracking,
   getShipmentStatus,
+  processingTotalPages,
+  shippedTotalPages,
+  onHoldTotalPages,
+  currentPage,
+  onPageChange,
 }) => {
   return (
     <Tabs defaultValue="ready-to-ship" className="space-y-4">
@@ -65,20 +76,25 @@ const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
             <CardDescription>Orders ready for shipment (no tracking assigned)</CardDescription>
           </CardHeader>
           <CardContent>
-            <ShipmentTable 
-              orders={readyToShipOrders} 
-              isLoading={processingLoading} 
-              showAddTracking={true}
-              trackingInputs={trackingInputs}
-              updatingOrderId={updatingOrderId}
-              onTrackingInputChange={onTrackingInputChange}
-              onAddTracking={onAddTracking}
-              onViewTracking={onViewTracking}
-              getShipmentStatus={getShipmentStatus}
-            />
-          </CardContent>
-        </Card>
-      </TabsContent>
+          <ShipmentTable
+            orders={readyToShipOrders}
+            isLoading={processingLoading}
+            showAddTracking={true}
+            trackingInputs={trackingInputs}
+            updatingOrderId={updatingOrderId}
+            onTrackingInputChange={onTrackingInputChange}
+            onAddTracking={onAddTracking}
+            onViewTracking={onViewTracking}
+            getShipmentStatus={getShipmentStatus}
+          />
+          <ShipmentPagination
+            totalPages={processingTotalPages}
+            currentPage={currentPage}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+    </TabsContent>
 
       <TabsContent value="in-transit">
         <Card>
@@ -87,20 +103,25 @@ const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
             <CardDescription>Orders with tracking numbers being shipped</CardDescription>
           </CardHeader>
           <CardContent>
-            <ShipmentTable 
-              orders={inTransitOrders} 
-              isLoading={processingLoading}
-              showTracking={true}
-              trackingInputs={trackingInputs}
-              updatingOrderId={updatingOrderId}
-              onTrackingInputChange={onTrackingInputChange}
-              onAddTracking={onAddTracking}
-              onViewTracking={onViewTracking}
-              getShipmentStatus={getShipmentStatus}
-            />
-          </CardContent>
-        </Card>
-      </TabsContent>
+          <ShipmentTable
+            orders={inTransitOrders}
+            isLoading={processingLoading}
+            showTracking={true}
+            trackingInputs={trackingInputs}
+            updatingOrderId={updatingOrderId}
+            onTrackingInputChange={onTrackingInputChange}
+            onAddTracking={onAddTracking}
+            onViewTracking={onViewTracking}
+            getShipmentStatus={getShipmentStatus}
+          />
+          <ShipmentPagination
+            totalPages={processingTotalPages}
+            currentPage={currentPage}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+    </TabsContent>
 
       <TabsContent value="exceptions">
         <Card>
@@ -109,19 +130,24 @@ const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
             <CardDescription>Orders with shipping issues that need attention</CardDescription>
           </CardHeader>
           <CardContent>
-            <ShipmentTable 
-              orders={onHoldOrders} 
-              isLoading={onHoldLoading}
-              trackingInputs={trackingInputs}
-              updatingOrderId={updatingOrderId}
-              onTrackingInputChange={onTrackingInputChange}
-              onAddTracking={onAddTracking}
-              onViewTracking={onViewTracking}
-              getShipmentStatus={getShipmentStatus}
-            />
-          </CardContent>
-        </Card>
-      </TabsContent>
+          <ShipmentTable
+            orders={onHoldOrders}
+            isLoading={onHoldLoading}
+            trackingInputs={trackingInputs}
+            updatingOrderId={updatingOrderId}
+            onTrackingInputChange={onTrackingInputChange}
+            onAddTracking={onAddTracking}
+            onViewTracking={onViewTracking}
+            getShipmentStatus={getShipmentStatus}
+          />
+          <ShipmentPagination
+            totalPages={onHoldTotalPages}
+            currentPage={currentPage}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+    </TabsContent>
 
       <TabsContent value="delivered">
         <Card>
@@ -130,20 +156,25 @@ const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
             <CardDescription>Successfully delivered shipments</CardDescription>
           </CardHeader>
           <CardContent>
-            <ShipmentTable 
-              orders={shippedOrders} 
-              isLoading={shippedLoading}
-              showTracking={true}
-              trackingInputs={trackingInputs}
-              updatingOrderId={updatingOrderId}
-              onTrackingInputChange={onTrackingInputChange}
-              onAddTracking={onAddTracking}
-              onViewTracking={onViewTracking}
-              getShipmentStatus={getShipmentStatus}
-            />
-          </CardContent>
-        </Card>
-      </TabsContent>
+          <ShipmentTable
+            orders={shippedOrders}
+            isLoading={shippedLoading}
+            showTracking={true}
+            trackingInputs={trackingInputs}
+            updatingOrderId={updatingOrderId}
+            onTrackingInputChange={onTrackingInputChange}
+            onAddTracking={onAddTracking}
+            onViewTracking={onViewTracking}
+            getShipmentStatus={getShipmentStatus}
+          />
+          <ShipmentPagination
+            totalPages={shippedTotalPages}
+            currentPage={currentPage}
+            onPageChange={onPageChange}
+          />
+        </CardContent>
+      </Card>
+    </TabsContent>
     </Tabs>
   );
 };

--- a/src/pages/LogisticsShipping.tsx
+++ b/src/pages/LogisticsShipping.tsx
@@ -10,6 +10,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 
 const LogisticsShipping = () => {
   const [searchTerm, setSearchTerm] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const perPage = 50;
   const [trackingInputs, setTrackingInputs] = useState<Record<number, string>>({});
   const [updatingOrderId, setUpdatingOrderId] = useState<number | null>(null);
   const [selectedOrderTracking, setSelectedOrderTracking] = useState<{orderId: number, trackingNumber: string} | null>(null);
@@ -17,18 +19,30 @@ const LogisticsShipping = () => {
   // Get tracking keys for dynamic key detection
   const { data: trackingKeys } = useTrackingDetection();
 
-  const { data: processingData, isLoading: processingLoading } = useOrders({ 
+  const { data: processingData, isLoading: processingLoading } = useOrders({
     status: 'processing',
-    search: searchTerm 
+    search: searchTerm,
+    per_page: perPage,
+    page: currentPage,
   });
-  const { data: shippedData, isLoading: shippedLoading } = useOrders({ 
+  const { data: shippedData, isLoading: shippedLoading } = useOrders({
     status: 'completed',
-    search: searchTerm 
+    search: searchTerm,
+    per_page: perPage,
+    page: currentPage,
   });
-  const { data: onHoldData, isLoading: onHoldLoading } = useOrders({ 
+  const { data: onHoldData, isLoading: onHoldLoading } = useOrders({
     status: 'on-hold',
-    search: searchTerm 
+    search: searchTerm,
+    per_page: perPage,
+    page: currentPage,
   });
+
+  const queries = {
+    processing: processingData,
+    shipped: shippedData,
+    onHold: onHoldData,
+  };
 
   // Extract orders from data wrapper
   const processingOrders = processingData?.data || [];
@@ -137,6 +151,11 @@ const LogisticsShipping = () => {
         onAddTracking={handleAddTracking}
         onViewTracking={handleViewTracking}
         getShipmentStatus={getShipmentStatus}
+        processingTotalPages={processingData?.totalPages || 1}
+        shippedTotalPages={shippedData?.totalPages || 1}
+        onHoldTotalPages={onHoldData?.totalPages || 1}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
       />
 
       {/* Enhanced Tracking Dialog */}


### PR DESCRIPTION
## Summary
- add `ShipmentPagination` component
- show pagination inside each logistics tab
- fetch orders with `page` and `per_page` params

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b475ad484832f85ac1b1877feb783