### PR TITLE
Fix dashboard top sellers

### DIFF
--- a/src/hooks/useWooCommerce.ts
+++ b/src/hooks/useWooCommerce.ts
@@ -20,10 +20,11 @@ export {
   useCustomerAcquisition 
 } from './useWooCommerceCustomers';
 export { 
-  useSalesReport, 
-  useTopSellers, 
-  useExportData, 
-  useCategorySales 
+  useSalesReport,
+  useTopSellers,
+  useTopSellingProducts,
+  useExportData,
+  useCategorySales
 } from './useWooCommerceReports';
 export { 
   useOrderStats, 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Package, Truck, CheckCircle, AlertTriangle, DollarSign, TrendingUp, Bell, Settings, Loader2 } from 'lucide-react';
-import { useOrderStats, useProductStats, useWooCommerceConfig, useTopSellers } from '../hooks/useWooCommerce';
+import { useOrderStats, useProductStats, useWooCommerceConfig, useTopSellingProducts } from '../hooks/useWooCommerce';
 import { useSupabaseNotifications } from '../hooks/useSupabaseNotifications';
 import { toast } from 'sonner';
 import { Link } from 'react-router-dom';
@@ -19,8 +19,8 @@ const Dashboard = () => {
   const thirtyDaysAgo = new Date();
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   
-  const { data: topSellers = [], isLoading: topSellersLoading } = useTopSellers({
-    per_page: 5
+  const { data: topSellers = [], isLoading: topSellersLoading } = useTopSellingProducts({
+    per_page: 10
     // Using default date range from the hook
   });
 
@@ -190,20 +190,21 @@ const Dashboard = () => {
                   <p className="text-sm text-muted-foreground mt-2">Loading top sellers...</p>
                 </div>
               ) : topSellers && topSellers.length > 0 ? (
-                topSellers.slice(0, 5).map((product, index) => (
-                  <div key={`${product.product_id}-${index}`} className="flex items-center justify-between">
+                topSellers.slice(0, 10).map((product, index) => (
+                  <div key={`${product.id}-${index}`} className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                       <div className="w-8 h-8 bg-primary/10 rounded-full flex items-center justify-center text-xs font-medium">
                         {index + 1}
                       </div>
+                      {product.image && (
+                        <img src={product.image} alt={product.name} className="w-8 h-8 rounded object-cover" />
+                      )}
                       <div>
-                        <p className="font-medium text-sm">{product.product_name || 'Unknown Product'}</p>
-                        <p className="text-xs text-muted-foreground">{product.quantity || 0} sold</p>
+                        <p className="font-medium text-sm">{product.name}</p>
+                        <p className="text-xs text-muted-foreground">SKU: {product.sku || 'N/A'}</p>
                       </div>
                     </div>
-                    <Badge variant="secondary">
-                      ${product.product_price || '0.00'}
-                    </Badge>
+                    <Badge variant="secondary">{product.quantity} sold</Badge>
                   </div>
                 ))
               ) : (

--- a/src/services/woocommerce/index.ts
+++ b/src/services/woocommerce/index.ts
@@ -24,6 +24,7 @@ class WooCommerceService {
 
   public getProducts: WooCommerceProductsService['getProducts'];
   public getProduct: WooCommerceProductsService['getProduct'];
+  public getProductsByIds: WooCommerceProductsService['getProductsByIds'];
   public updateProduct: WooCommerceProductsService['updateProduct'];
   public getCategories: WooCommerceProductsService['getCategories'];
 
@@ -54,6 +55,7 @@ class WooCommerceService {
 
     this.getProducts = this.productsService.getProducts.bind(this.productsService);
     this.getProduct = this.productsService.getProduct.bind(this.productsService);
+    this.getProductsByIds = this.productsService.getProductsByIds.bind(this.productsService);
     this.updateProduct = this.productsService.updateProduct.bind(this.productsService);
     this.getCategories = this.productsService.getCategories.bind(this.productsService);
 

--- a/src/services/woocommerce/products.ts
+++ b/src/services/woocommerce/products.ts
@@ -44,6 +44,19 @@ export class WooCommerceProductsService extends BaseWooCommerceService {
     return response.json();
   }
 
+  async getProductsByIds(ids: number[]): Promise<WooCommerceProduct[]> {
+    if (!ids || ids.length === 0) return [];
+    const uniqueIds = Array.from(new Set(ids));
+    const queryParams = new URLSearchParams();
+    queryParams.append('include', uniqueIds.join(','));
+    const perPage = Math.min(Math.max(uniqueIds.length, 1), 100);
+    queryParams.append('per_page', perPage.toString());
+    const endpoint = `/products?${queryParams.toString()}`;
+    const response = await this.makeRequest(endpoint);
+    const data = await response.json();
+    return Array.isArray(data) ? data : [];
+  }
+
   async updateProduct(productId: number, data: Partial<WooCommerceProduct>): Promise<WooCommerceProduct> {
     console.log('Updating product:', productId, data);
     


### PR DESCRIPTION
## Summary
- fetch product details in WooCommerce reports service
- expose new method in service index
- provide `useTopSellingProducts` hook for aggregated data
- display product image, sku and quantity for top sellers
- adjust dashboard to show top 10 products

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b48b2c280832fa9b6ca80dfac1aa1