### PR TITLE
Fix tab totals to show full order counts

### DIFF
--- a/src/components/logistics/ShipmentTabs.tsx
+++ b/src/components/logistics/ShipmentTabs.tsx
@@ -12,6 +12,10 @@ interface ShipmentTabsProps {
   inTransitOrders: any[];
   onHoldOrders: any[];
   shippedOrders: any[];
+  readyToShipCount?: number;
+  inTransitCount?: number;
+  onHoldCount?: number;
+  shippedCount?: number;
   processingLoading: boolean;
   onHoldLoading: boolean;
   shippedLoading: boolean;
@@ -33,6 +37,10 @@ const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
   inTransitOrders,
   onHoldOrders,
   shippedOrders,
+  readyToShipCount,
+  inTransitCount,
+  onHoldCount,
+  shippedCount,
   processingLoading,
   onHoldLoading,
   shippedLoading,
@@ -53,19 +61,19 @@ const ShipmentTabs: React.FC<ShipmentTabsProps> = ({
       <TabsList className="grid w-full grid-cols-4">
         <TabsTrigger value="ready-to-ship" className="flex items-center gap-2">
           <Package className="w-4 h-4" />
-          Ready to Ship <Badge variant="secondary">{readyToShipOrders?.length || 0}</Badge>
+          Ready to Ship <Badge variant="secondary">{(readyToShipCount ?? readyToShipOrders?.length) || 0}</Badge>
         </TabsTrigger>
         <TabsTrigger value="in-transit" className="flex items-center gap-2">
           <Truck className="w-4 h-4" />
-          In Transit <Badge variant="secondary">{inTransitOrders?.length || 0}</Badge>
+          In Transit <Badge variant="secondary">{(inTransitCount ?? inTransitOrders?.length) || 0}</Badge>
         </TabsTrigger>
         <TabsTrigger value="exceptions" className="flex items-center gap-2">
           <AlertTriangle className="w-4 h-4" />
-          Exceptions <Badge variant="destructive">{onHoldOrders?.length || 0}</Badge>
+          Exceptions <Badge variant="destructive">{(onHoldCount ?? onHoldOrders?.length) || 0}</Badge>
         </TabsTrigger>
         <TabsTrigger value="delivered" className="flex items-center gap-2">
           <CheckCircle className="w-4 h-4" />
-          Delivered <Badge variant="secondary">{shippedOrders?.length || 0}</Badge>
+          Delivered <Badge variant="secondary">{(shippedCount ?? shippedOrders?.length) || 0}</Badge>
         </TabsTrigger>
       </TabsList>
 

--- a/src/components/order-management/OrderTabsContainer.tsx
+++ b/src/components/order-management/OrderTabsContainer.tsx
@@ -42,15 +42,15 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
 }) => {
   // Order counts for tabs
   const orderCounts = {
-    pending: ordersByStatus.pending?.length || 0,
-    processing: ordersByStatus.processing?.length || 0,
-    inTransit: ordersByStatus.inTransit?.length || 0,
-    onHold: ordersByStatus.onHold?.length || 0,
-    completed: ordersByStatus.completed?.length || 0,
-    cancelled: ordersByStatus.cancelled?.length || 0,
-    refunded: ordersByStatus.refunded?.length || 0,
-    failed: ordersByStatus.failed?.length || 0,
-    pendingPayment: ordersByStatus.pendingPayment?.length || 0
+    pending: queries.pending.data?.totalRecords || 0,
+    processing: queries.processing.data?.totalRecords || 0,
+    inTransit: queries.inTransit.data?.totalRecords || 0,
+    onHold: queries.onHold.data?.totalRecords || 0,
+    completed: queries.completed.data?.totalRecords || 0,
+    cancelled: queries.cancelled.data?.totalRecords || 0,
+    refunded: queries.refunded.data?.totalRecords || 0,
+    failed: queries.failed.data?.totalRecords || 0,
+    pendingPayment: queries.pendingPayment.data?.totalRecords || 0
   };
 
   return (
@@ -96,7 +96,7 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
         isLoading={queries.inTransit.isLoading}
         showTracking={true}
         totalPages={queries.inTransit.data?.totalPages || 1}
-        totalRecords={ordersByStatus.inTransit.length}
+        totalRecords={queries.inTransit.data?.totalRecords}
         currentPage={currentPage}
         onPageChange={onPageChange}
         onEditOrder={onEditOrder}
@@ -111,6 +111,7 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
         orders={ordersByStatus.onHold}
         isLoading={queries.onHold.isLoading}
         totalPages={queries.onHold.data?.totalPages || 1}
+        totalRecords={queries.onHold.data?.totalRecords}
         currentPage={currentPage}
         onPageChange={onPageChange}
         onEditOrder={onEditOrder}
@@ -126,6 +127,7 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
         isLoading={queries.completed.isLoading}
         showTracking={true}
         totalPages={queries.completed.data?.totalPages || 1}
+        totalRecords={queries.completed.data?.totalRecords}
         currentPage={currentPage}
         onPageChange={onPageChange}
         onEditOrder={onEditOrder}
@@ -140,6 +142,7 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
         orders={ordersByStatus.cancelled}
         isLoading={queries.cancelled.isLoading}
         totalPages={queries.cancelled.data?.totalPages || 1}
+        totalRecords={queries.cancelled.data?.totalRecords}
         currentPage={currentPage}
         onPageChange={onPageChange}
         onEditOrder={onEditOrder}
@@ -154,6 +157,7 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
         orders={ordersByStatus.refunded}
         isLoading={queries.refunded.isLoading}
         totalPages={queries.refunded.data?.totalPages || 1}
+        totalRecords={queries.refunded.data?.totalRecords}
         currentPage={currentPage}
         onPageChange={onPageChange}
         onEditOrder={onEditOrder}
@@ -168,6 +172,7 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
         orders={ordersByStatus.failed}
         isLoading={queries.failed.isLoading}
         totalPages={queries.failed.data?.totalPages || 1}
+        totalRecords={queries.failed.data?.totalRecords}
         currentPage={currentPage}
         onPageChange={onPageChange}
         onEditOrder={onEditOrder}

--- a/src/pages/LogisticsShipping.tsx
+++ b/src/pages/LogisticsShipping.tsx
@@ -19,6 +19,8 @@ const LogisticsShipping = () => {
   // Get tracking keys for dynamic key detection
   const { data: trackingKeys } = useTrackingDetection();
 
+  const primaryTrackingKey = trackingKeys?.[0] || '_wot_tracking_number';
+
   const { data: processingData, isLoading: processingLoading } = useOrders({
     status: 'processing',
     search: searchTerm,
@@ -38,6 +40,15 @@ const LogisticsShipping = () => {
     page: currentPage,
   });
 
+  const { data: inTransitCountData } = useOrders({
+    status: 'processing',
+    search: searchTerm,
+    per_page: 1,
+    page: 1,
+    meta_key: primaryTrackingKey,
+    meta_compare: 'EXISTS'
+  });
+
   const queries = {
     processing: processingData,
     shipped: shippedData,
@@ -52,6 +63,12 @@ const LogisticsShipping = () => {
   // Filter orders based on tracking status for proper categorization using imported utility
   const readyToShipOrders = processingOrders.filter(order => !getTrackingNumber(order));
   const inTransitOrders = processingOrders.filter(order => getTrackingNumber(order));
+
+  const processingCount = processingData?.totalRecords || 0;
+  const inTransitCount = inTransitCountData?.totalRecords || 0;
+  const readyToShipCount = Math.max(processingCount - inTransitCount, 0);
+  const onHoldCount = onHoldData?.totalRecords || 0;
+  const shippedCount = shippedData?.totalRecords || 0;
 
   const updateOrderMutation = useUpdateOrder();
 
@@ -139,9 +156,13 @@ const LogisticsShipping = () => {
 
       <ShipmentTabs
         readyToShipOrders={readyToShipOrders}
+        readyToShipCount={readyToShipCount}
         inTransitOrders={inTransitOrders}
+        inTransitCount={inTransitCount}
         onHoldOrders={onHoldOrders}
+        onHoldCount={onHoldCount}
         shippedOrders={shippedOrders}
+        shippedCount={shippedCount}
         processingLoading={processingLoading}
         onHoldLoading={onHoldLoading}
         shippedLoading={shippedLoading}


### PR DESCRIPTION
## Summary
- show WooCommerce total counts in order tabs
- support count props for logistics shipment tabs
- display global counts on Logistics page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b4a742370832f99c27c5fa46e8521