### PR TITLE
Fix WooCommerce dashboard stats

### DIFF
--- a/src/components/order-management/OrderTabsContainer.tsx
+++ b/src/components/order-management/OrderTabsContainer.tsx
@@ -54,23 +54,8 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
   };
 
   return (
-    <Tabs defaultValue="pending" className="space-y-4">
+    <Tabs defaultValue="processing" className="space-y-4">
       <OrderTabsHeader orderCounts={orderCounts} />
-
-      <OrderTabContent
-        value="pending"
-        title="Pending Orders"
-        description="Orders waiting to be processed"
-        orders={ordersByStatus.pending}
-        isLoading={queries.pending.isLoading}
-        totalPages={queries.pending.data?.totalPages || 1}
-        totalRecords={queries.pending.data?.totalRecords}
-        currentPage={currentPage}
-        onPageChange={onPageChange}
-        onEditOrder={onEditOrder}
-        getStatusColor={getStatusColor}
-        getTrackingNumber={getTrackingNumber}
-      />
 
       <OrderTabContent
         value="processing"
@@ -81,6 +66,21 @@ const OrderTabsContainer: React.FC<OrderTabsContainerProps> = ({
         showTracking={true}
         totalPages={queries.processing.data?.totalPages || 1}
         totalRecords={queries.processing.data?.totalRecords}
+        currentPage={currentPage}
+        onPageChange={onPageChange}
+        onEditOrder={onEditOrder}
+        getStatusColor={getStatusColor}
+        getTrackingNumber={getTrackingNumber}
+      />
+
+      <OrderTabContent
+        value="pending"
+        title="Pending Orders"
+        description="Orders waiting to be processed"
+        orders={ordersByStatus.pending}
+        isLoading={queries.pending.isLoading}
+        totalPages={queries.pending.data?.totalPages || 1}
+        totalRecords={queries.pending.data?.totalRecords}
         currentPage={currentPage}
         onPageChange={onPageChange}
         onEditOrder={onEditOrder}

--- a/src/components/order-management/OrderTabsHeader.tsx
+++ b/src/components/order-management/OrderTabsHeader.tsx
@@ -20,11 +20,11 @@ interface OrderTabsHeaderProps {
 const OrderTabsHeader: React.FC<OrderTabsHeaderProps> = ({ orderCounts }) => {
   return (
     <TabsList className="grid w-full grid-cols-9">
-      <TabsTrigger value="pending" className="flex items-center gap-2">
-        Pending <Badge variant="secondary">{orderCounts.pending}</Badge>
-      </TabsTrigger>
       <TabsTrigger value="processing" className="flex items-center gap-2">
         Processing <Badge variant="secondary">{orderCounts.processing}</Badge>
+      </TabsTrigger>
+      <TabsTrigger value="pending" className="flex items-center gap-2">
+        Pending <Badge variant="secondary">{orderCounts.pending}</Badge>
       </TabsTrigger>
       <TabsTrigger value="in-transit" className="flex items-center gap-2">
         In Transit <Badge variant="secondary">{orderCounts.inTransit}</Badge>

--- a/src/hooks/useWooCommerceReports.ts
+++ b/src/hooks/useWooCommerceReports.ts
@@ -90,9 +90,8 @@ export const useTopSellingProducts = (params?: {
 }) => {
   const { isConfigured } = useWooCommerceConfig();
 
-  const dateParams = params?.date_min && params?.date_max ?
-    params :
-    { ...params, ...getLastThirtyDaysRange() };
+  const shouldUseDefaultRange = !params?.period && !params?.date_min && !params?.date_max;
+  const dateParams = shouldUseDefaultRange ? { ...params, ...getLastThirtyDaysRange() } : params;
 
   return useQuery({
     queryKey: ['top-selling-products', dateParams],

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -20,8 +20,8 @@ const Dashboard = () => {
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   
   const { data: topSellers = [], isLoading: topSellersLoading } = useTopSellingProducts({
-    per_page: 10
-    // Using default date range from the hook
+    per_page: 10,
+    period: 'all'
   });
 
   useEffect(() => {

--- a/src/pages/LogisticsShipping.tsx
+++ b/src/pages/LogisticsShipping.tsx
@@ -28,7 +28,7 @@ const LogisticsShipping = () => {
     page: currentPage,
   });
   const { data: shippedData, isLoading: shippedLoading } = useOrders({
-    status: 'completed',
+    status: 'completed,delivered,shipped',
     search: searchTerm,
     per_page: perPage,
     page: currentPage,
@@ -76,8 +76,10 @@ const LogisticsShipping = () => {
     const tracking = getTrackingNumber(order);
     if (!tracking) return { status: 'No Tracking', color: 'bg-gray-100 text-gray-800' };
     
-    if (order.status === 'completed') {
+    if (order.status === 'completed' || order.status === 'delivered') {
       return { status: 'Delivered', color: 'bg-green-100 text-green-800' };
+    } else if (order.status === 'shipped') {
+      return { status: 'Shipped', color: 'bg-green-100 text-green-800' };
     } else if (order.status === 'processing' && tracking) {
       return { status: 'In Transit', color: 'bg-blue-100 text-blue-800' };
     } else if (order.status === 'on-hold') {


### PR DESCRIPTION
## Summary
- show top selling products from all-time sales
- support delivered and shipped statuses in logistics
- fetch accurate order stats using WooCommerce API
- move Processing tab first in Orders UI

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b4df70f5c832fac9a9e81515b85d1